### PR TITLE
Remove TranslucentSearchMenu JSON

### DIFF
--- a/Themes/TranslucentStartMenu/README.md
+++ b/Themes/TranslucentStartMenu/README.md
@@ -74,45 +74,4 @@ To add this feature go to Start Menu Styler > **Advanced** > **Custom process
 inclusion list**, add `SearchHost.exe` to the process list and click save.
 
 ![TranslucentSearchMenu gif](TranslucentSearchMenu.gif)
-
-Copy the JSON code to Start Menu Styler > **Advanced** > inside **Mod settings**
-and click save.
-
-```json
-{
-  "controlStyles[0].target": "Border#AcrylicBorder",
-  "controlStyles[0].styles[0]": "CornerRadius=15",
-  "controlStyles[0].styles[1]": "Background:=<AcrylicBrush TintColor=\"Transparent\" TintLuminosityOpacity=\"0\" TintOpacity=\"0\" Opacity=\"1\" FallbackColor=\"#000000\"/>",
-  "controlStyles[0].styles[2]": "BorderThickness=0,0,0,0",
-  "controlStyles[1].target": "Border#AcrylicOverlay",
-  "controlStyles[1].styles[0]": "Visibility=Collapsed",
-  "controlStyles[2].target": "Border#BorderElement",
-  "controlStyles[2].styles[0]": "CornerRadius=10",
-  "controlStyles[2].styles[1]": "BorderThickness=0,0,0,0",
-  "controlStyles[2].styles[2]": "Background:=<AcrylicBrush TintLuminosityOpacity=\"0.03\" TintOpacity=\"0\" Opacity=\"1\" FallbackColor=\"#000000\"/>",
-  "controlStyles[3].target": "Grid#ShowMoreSuggestions",
-  "controlStyles[3].styles[0]": "Visibility=Collapsed",
-  "controlStyles[4].target": "Grid#SuggestionsParentContainer",
-  "controlStyles[4].styles[0]": "Visibility=Collapsed",
-  "controlStyles[5].target": "Grid#TopLevelSuggestionsListHeader",
-  "controlStyles[5].styles[0]": "Visibility=Collapsed",
-  "controlStyles[6].target": "StartMenu.PinnedList",
-  "controlStyles[6].styles[0]": "Height=504",
-  "controlStyles[7].target": "MenuFlyoutPresenter",
-  "controlStyles[7].styles[0]": "Background:=<AcrylicBrush TintColor=\"Transparent\" TintLuminosityOpacity=\"0\" TintOpacity=\"0\" Opacity=\"1\" FallbackColor=\"#000000\"/>",
-  "controlStyles[7].styles[1]": "BorderThickness=0,0,0,0",
-  "controlStyles[8].target": "Border#AppBorder",
-  "controlStyles[8].styles[0]": "Background:=<AcrylicBrush TintColor=\"Transparent\" TintLuminosityOpacity=\"0\" TintOpacity=\"0\" Opacity=\"1\" FallbackColor=\"#000000\"/>",
-  "controlStyles[8].styles[1]": "BorderThickness=0,0,0,0",
-  "controlStyles[9].target": "Border#AccentAppBorder",
-  "controlStyles[9].styles[0]": "Background:=<AcrylicBrush TintColor=\"Transparent\" TintLuminosityOpacity=\"0\" TintOpacity=\"0\" Opacity=\"1\" FallbackColor=\"#000000\"/>",
-  "controlStyles[9].styles[1]": "BorderThickness=0,0,0,0",
-  "controlStyles[10].target": "Border#LayerBorder",
-  "controlStyles[10].styles[0]": "Visibility=Collapsed",
-  "controlStyles[11].target": "Border#TaskbarSearchBackground",
-  "controlStyles[11].styles[0]": "Background:=<AcrylicBrush TintColor=\"Transparent\" TintLuminosityOpacity=\"0.03\" TintOpacity=\"0\" Opacity=\"1\" FallbackColor=\"#000000\"/>",
-  "controlStyles[11].styles[1]": "CornerRadius=10",
-  "controlStyles[11].styles[2]": "BorderThickness=0,0,0,0"
-}
-```
 </details>


### PR DESCRIPTION
It's identical to the other JSON except for the fallback color (unintended?), and since the styles for the start menu also apply to the search host, the additional step of adding `SearchHost.exe` should be enough, even if using the theme that's bundled with the mod.

@bbmaster123 @Undisputed00x what do you think?