### PR TITLE
Change StartMenu.PinnedList height to Auto

### DIFF
--- a/Themes/RosePine/README.md
+++ b/Themes/RosePine/README.md
@@ -53,7 +53,7 @@ controlStyles:
       - BorderThickness=0
   - target: StartMenu.PinnedList
     styles:
-      - Height=340
+      - Height=Auto
       - Width=342
   - target: StartDocked.NavigationPaneView#Margin
     styles:

--- a/Themes/RosePine/README.md
+++ b/Themes/RosePine/README.md
@@ -215,7 +215,7 @@ controlStyles:
       - Visibility=Collapsed
   - target: StartMenu.PinnedList
     styles:
-      - Height=Auto
+      - Height=340
   - target: StartDocked.NavigationPaneView#Margin
     styles:
       - Margin=210,0,210,0

--- a/Themes/RosePine/README.md
+++ b/Themes/RosePine/README.md
@@ -215,7 +215,7 @@ controlStyles:
       - Visibility=Collapsed
   - target: StartMenu.PinnedList
     styles:
-      - Height=340
+      - Height=Auto
   - target: StartDocked.NavigationPaneView#Margin
     styles:
       - Margin=210,0,210,0


### PR DESCRIPTION
A small fix for programs that are pinned to start for RosePine theme. Due to the `Height=340` value, the amount of pinned items was limited.

Before (340 - no other pinned to start items displayed, even though they were pinned):
<img width="771" height="780" alt="image" src="https://github.com/user-attachments/assets/1f3a901a-02bb-4738-b2fa-dcf92a546a55" />

After (Auto - other previously pinned items are displayed and can be scrolled through):
<img width="769" height="779" alt="image" src="https://github.com/user-attachments/assets/051b4a58-85c0-48c5-b28b-249d40072d65" />

