### PR TITLE
Remove `RenderTransform` Crash-causing style on specific target

### DIFF
--- a/Themes/LiquidGlass2/README.md
+++ b/Themes/LiquidGlass2/README.md
@@ -557,8 +557,6 @@ controlStyles:
       - Height=Auto
   - target: StartMenu.PinnedListTile > Grid#Root > Grid#LogoContainer
     styles:
-      - RenderTransformOrigin=0.5,0.5
-      - RenderTransform:=<ScaleTransform ScaleX="1.02" ScaleY="1.02" />
       - ActualHeight=>PinAppHyt
       - ActualWidth=>PinAppWid
       - MinHeight=39


### PR DESCRIPTION
This PR removes `ScaleTransform` from `StartMenu.PinnedListTile > Grid#Root > Grid#LogoContainer`

Applying a `ScaleTransform` on the target caused a crash every time a pinned app was dragged around, usually within a second or two, depending on what direction the drag was made (if it overlapped another pinned app or not). Adding a `@State` had no effect, and I could not personally come up with a proper `@CommonStates` target modifier or any similar change that could apply the transform without causing a crash. As such, I am submitting this PR to remove this style from the theme until (a) the odd BTS cause of this is solved, or (b) until further notice. I believe this crash was not caused in previous Windows builds, but I cannot pinpoint the exact update that changed it, especially with gradual rollouts.

Current Windows build: 26300.9278
Theme by: @mohsinhasanpc 

If the theme author can find a way to address this in a way that still applies their intended style, please do let me know so I can edit this PR, or I can close this, and the theme author can open a PR themselves with the alternative solution if they prefer.